### PR TITLE
Lazy evaluation of property

### DIFF
--- a/libraries/java_properties_resource.rb
+++ b/libraries/java_properties_resource.rb
@@ -24,7 +24,7 @@ class Chef
       # This allows us to define attributes dynamically
       # as attributes on the resource
       def method_missing(name, *args)
-        @properties_from_attributes[name.to_sym] = args[0].to_s
+        @properties_from_attributes[name.to_sym] = args[0]
       end
 
       # add a property with key, value
@@ -77,7 +77,7 @@ class Chef
 
       def action_merge
         current_properties = @current_resource.properties_from_file
-        new_properties = new_resource.properties_from_attributes
+        new_properties = Hash[new_resource.properties_from_attributes.map { |(k, v)| [k.to_sym, (v.respond_to?(:call) ? v.call : v).to_s] }]
         merged = current_properties.merge(new_properties)
 
         if merged != current_properties

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ryan.mango.larson@gmail.com'
 license          'MIT'
 description      'Provides a resource for interacting with Java properties files'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.3'
+version          '0.1.4'


### PR DESCRIPTION
Just a little change in order to be able to evaluate the value of the property with a closure during execution phase.
```
java_properties '<properties_file>' do

   property 'key', lazy { node.run_state['runtime_var'] }

end
````