### PR TITLE
Chef Infra Client 16 and later a legacy HWRP resource must use provides.

### DIFF
--- a/libraries/java_properties_resource.rb
+++ b/libraries/java_properties_resource.rb
@@ -10,6 +10,8 @@ require 'java-properties'
 class Chef
   class Resource
     class JavaProperties < Chef::Resource
+      resource_name :java_properties
+      provides :java_properties
 
       def initialize(name, run_context=nil)
         super


### PR DESCRIPTION
Chef Infra Client 16 and later a legacy HWRP resource must use provides to define how the resource is called in recipes or other resources.

https://docs.chef.io/workstation/cookstyle/chef_deprecations_hwrpwithoutprovides/